### PR TITLE
Restore admin access and stabilize Supabase UX flows

### DIFF
--- a/app/(protected)/admin/page.tsx
+++ b/app/(protected)/admin/page.tsx
@@ -1,0 +1,102 @@
+import { redirect } from 'next/navigation'
+import { createServerComponentClient } from '@supabase/auth-helpers-nextjs'
+import { cookies } from 'next/headers'
+import { Database } from '@/lib/supabase-types'
+import { AdminPanel } from '@/components/admin/admin-panel'
+import { AccessDenied } from '@/components/admin/access-denied'
+import { normalizeStatus } from '@/lib/task-status'
+import { TaskStatus, Task, Project, Goal } from '@/lib/types'
+
+export default async function AdminPage() {
+  const supabase = createServerComponentClient<Database>({ cookies })
+  const {
+    data: { session }
+  } = await supabase.auth.getSession()
+
+  if (!session) {
+    redirect('/login')
+  }
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('role, full_name')
+    .eq('id', session.user.id)
+    .single()
+
+  const role = (profile?.role as 'admin' | 'user' | null) ?? 'user'
+  const displayName =
+    profile?.full_name ??
+    (session.user.user_metadata?.full_name as string | undefined) ??
+    session.user.email ??
+    'Kullanıcı'
+
+  if (role !== 'admin') {
+    return <AccessDenied fullName={displayName} />
+  }
+
+  const [tasksResult, projectsResult, goalsResult, revisionsResult] = await Promise.all([
+    supabase
+      .from('tasks')
+      .select('id, title, description, status, priority, due_date, project_id, user_id, created_at')
+      .eq('user_id', session.user.id),
+    supabase
+      .from('projects')
+      .select('id, title, description, progress, due_date, user_id, created_at')
+      .eq('user_id', session.user.id),
+    supabase
+      .from('goals')
+      .select('id, title, description, is_completed, user_id, created_at')
+      .eq('user_id', session.user.id),
+    supabase
+      .from('revisions')
+      .select('id, task_id, description, created_at, user_id, tasks(title), profiles(full_name, email)')
+      .eq('user_id', session.user.id)
+      .order('created_at', { ascending: false })
+  ])
+
+  const tasks: Task[] = (tasksResult.data ?? []).map((task) => ({
+    id: task.id,
+    title: task.title,
+    description: task.description,
+    status: normalizeStatus(task.status as TaskStatus),
+    priority: (task.priority as Task['priority']) ?? 'medium',
+    due_date: task.due_date,
+    project_id: task.project_id,
+    user_id: task.user_id,
+    created_at: task.created_at
+  }))
+
+  const projects: Project[] = (projectsResult.data ?? []).map((project) => ({
+    id: project.id,
+    title: project.title,
+    description: project.description,
+    progress: project.progress ?? 0,
+    due_date: project.due_date,
+    user_id: project.user_id,
+    created_at: project.created_at
+  }))
+
+  const goals: Goal[] = (goalsResult.data ?? []).map((goal) => ({
+    id: goal.id,
+    title: goal.title,
+    description: goal.description,
+    is_completed: goal.is_completed,
+    user_id: goal.user_id,
+    created_at: goal.created_at
+  }))
+
+  const revisions = (revisionsResult.data ?? []).map((revision) => ({
+    id: revision.id,
+    task_id: revision.task_id,
+    description: revision.description,
+    created_at: revision.created_at,
+    user_id: revision.user_id,
+    task_title: (revision.tasks as { title: string } | null)?.title ?? 'Görev',
+    author: {
+      full_name: (revision.profiles as { full_name: string | null } | null)?.full_name ?? null,
+      email: (revision.profiles as { email: string | null } | null)?.email ?? null
+    }
+  }))
+
+  return <AdminPanel tasks={tasks} projects={projects} goals={goals} revisions={revisions} />
+}

--- a/app/(protected)/goals/page.tsx
+++ b/app/(protected)/goals/page.tsx
@@ -1,0 +1,23 @@
+import { createServerComponentClient } from '@supabase/auth-helpers-nextjs'
+import { cookies } from 'next/headers'
+import { Database } from '@/lib/supabase-types'
+import { GoalsClient } from '@/components/goals/goals-client'
+
+export default async function GoalsPage() {
+  const supabase = createServerComponentClient<Database>({ cookies })
+  const {
+    data: { session }
+  } = await supabase.auth.getSession()
+
+  if (!session) {
+    return null
+  }
+
+  const { data: goalsData } = await supabase
+    .from('goals')
+    .select('*')
+    .eq('user_id', session.user.id)
+    .order('created_at', { ascending: true })
+
+  return <GoalsClient initialGoals={goalsData ?? []} />
+}

--- a/app/(protected)/layout.tsx
+++ b/app/(protected)/layout.tsx
@@ -12,12 +12,12 @@ export default async function ProtectedLayout({ children }: { children: ReactNod
   } = await supabase.auth.getSession()
 
   if (!session) {
-    redirect('/auth/login')
+    redirect('/login')
   }
 
   const { data: profile } = await supabase
     .from('profiles')
-    .select('full_name, email, theme')
+    .select('full_name, email, theme, role')
     .eq('id', session.user.id)
     .single()
 
@@ -27,7 +27,8 @@ export default async function ProtectedLayout({ children }: { children: ReactNod
     <DashboardShell
       user={{
         full_name: profile?.full_name ?? metadata?.full_name ?? session.user.email!,
-        email: profile?.email ?? session.user.email!
+        email: profile?.email ?? session.user.email!,
+        role: (profile?.role as 'admin' | 'user' | null) ?? 'user'
       }}
     >
       {children}

--- a/app/(protected)/settings/page.tsx
+++ b/app/(protected)/settings/page.tsx
@@ -27,7 +27,8 @@ export default async function SettingsPage() {
     theme: (profile?.theme as 'light' | 'dark' | null) ?? 'light',
     email_notifications: profile?.email_notifications ?? true,
     push_notifications: profile?.push_notifications ?? false,
-    weekly_summary: profile?.weekly_summary ?? true
+    weekly_summary: profile?.weekly_summary ?? true,
+    role: (profile?.role as 'admin' | 'user' | null) ?? 'user'
   }
 
   return <SettingsClient profile={mergedProfile} />

--- a/app/(protected)/tasks/page.tsx
+++ b/app/(protected)/tasks/page.tsx
@@ -2,6 +2,7 @@ import { createServerComponentClient } from '@supabase/auth-helpers-nextjs'
 import { cookies } from 'next/headers'
 import { Database } from '@/lib/supabase-types'
 import { KanbanBoard } from '@/components/tasks/kanban-board'
+import { RevisionFeed } from '@/components/tasks/revision-feed'
 
 export default async function TasksPage() {
   const supabase = createServerComponentClient<Database>({ cookies })
@@ -23,5 +24,29 @@ export default async function TasksPage() {
     .select('id, title')
     .eq('user_id', session.user.id)
 
-  return <KanbanBoard initialTasks={tasksData ?? []} projects={projectsData ?? []} />
+  const { data: revisionsData } = await supabase
+    .from('revisions')
+    .select('id, task_id, description, created_at, user_id, tasks(title), profiles(full_name, email)')
+    .eq('user_id', session.user.id)
+    .order('created_at', { ascending: false })
+
+  const revisions = (revisionsData ?? []).map((revision) => ({
+    id: revision.id,
+    task_id: revision.task_id,
+    description: revision.description,
+    created_at: revision.created_at,
+    user_id: revision.user_id,
+    task_title: (revision.tasks as { title: string } | null)?.title ?? 'Görev',
+    author: {
+      full_name: (revision.profiles as { full_name: string | null } | null)?.full_name ?? null,
+      email: (revision.profiles as { email: string | null } | null)?.email ?? null
+    }
+  }))
+
+  return (
+    <div className="space-y-6">
+      <KanbanBoard initialTasks={tasksData ?? []} projects={projectsData ?? []} />
+      <RevisionFeed initialRevisions={revisions} />
+    </div>
+  )
 }

--- a/app/api/goals/[id]/route.ts
+++ b/app/api/goals/[id]/route.ts
@@ -6,7 +6,6 @@ import { Database } from '@/lib/supabase-types'
 export async function PUT(request: Request, { params }: { params: { id: string } }) {
   const supabase = createRouteHandlerClient<Database>({ cookies })
   const body = await request.json()
-
   const {
     data: { session }
   } = await supabase.auth.getSession()
@@ -15,14 +14,14 @@ export async function PUT(request: Request, { params }: { params: { id: string }
     return NextResponse.json({ error: 'Yetkisiz erişim' }, { status: 401 })
   }
 
-  const updatePayload: Database['public']['Tables']['projects']['Update'] = {}
+  const updatePayload: Database['public']['Tables']['goals']['Update'] = {}
+
   if ('title' in body) updatePayload.title = body.title
   if ('description' in body) updatePayload.description = body.description
-  if ('progress' in body) updatePayload.progress = body.progress
-  if ('due_date' in body) updatePayload.due_date = body.due_date ? body.due_date : null
+  if ('is_completed' in body) updatePayload.is_completed = body.is_completed
 
   const { data, error } = await supabase
-    .from('projects')
+    .from('goals')
     .update(updatePayload)
     .eq('id', params.id)
     .eq('user_id', session.user.id)
@@ -46,7 +45,7 @@ export async function DELETE(_: Request, { params }: { params: { id: string } })
     return NextResponse.json({ error: 'Yetkisiz erişim' }, { status: 401 })
   }
 
-  const { error } = await supabase.from('projects').delete().eq('id', params.id).eq('user_id', session.user.id)
+  const { error } = await supabase.from('goals').delete().eq('id', params.id).eq('user_id', session.user.id)
 
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 })

--- a/app/api/profile/preferences/route.ts
+++ b/app/api/profile/preferences/route.ts
@@ -14,11 +14,23 @@ export async function PUT(request: Request) {
     return NextResponse.json({ error: 'Yetkisiz erişim' }, { status: 401 })
   }
 
-  const updatePayload = {
-    email_notifications: body.email_notifications,
-    push_notifications: body.push_notifications,
-    weekly_summary: body.weekly_summary,
-    theme: body.theme
+  const updatePayload: Database['public']['Tables']['profiles']['Update'] = {}
+
+  if ('email_notifications' in body) {
+    updatePayload.email_notifications = body.email_notifications
+  }
+  if ('push_notifications' in body) {
+    updatePayload.push_notifications = body.push_notifications
+  }
+  if ('weekly_summary' in body) {
+    updatePayload.weekly_summary = body.weekly_summary
+  }
+  if ('theme' in body) {
+    updatePayload.theme = body.theme
+  }
+
+  if (Object.keys(updatePayload).length === 0) {
+    return NextResponse.json({ error: 'Güncellenecek alan belirtilmedi.' }, { status: 400 })
   }
 
   const { error } = await supabase

--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from 'next/server'
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs'
 import { cookies } from 'next/headers'
 import { Database } from '@/lib/supabase-types'
+import { COMPLETED_STATUSES, normalizeStatus } from '@/lib/task-status'
+import { TaskStatus } from '@/lib/types'
 
 export async function GET() {
   const supabase = createRouteHandlerClient<Database>({ cookies })
@@ -13,7 +15,7 @@ export async function GET() {
     return NextResponse.json({ error: 'Yetkisiz erişim' }, { status: 401 })
   }
 
-  const { data, error } = await supabase
+  const { data: projects, error } = await supabase
     .from('projects')
     .select('*')
     .eq('user_id', session.user.id)
@@ -23,7 +25,46 @@ export async function GET() {
     return NextResponse.json({ error: error.message }, { status: 500 })
   }
 
-  return NextResponse.json(data)
+  const projectsWithProgress = [...(projects ?? [])]
+
+  const projectIds = projectsWithProgress.map((project) => project.id)
+
+  if (projectIds.length > 0) {
+    const { data: tasksData } = await supabase
+      .from('tasks')
+      .select('project_id, status')
+      .in('project_id', projectIds)
+
+    const grouped = new Map<string, { total: number; completed: number }>()
+
+    tasksData?.forEach((task) => {
+      if (!task.project_id) return
+      const normalized = normalizeStatus(task.status as TaskStatus)
+      const entry = grouped.get(task.project_id) ?? { total: 0, completed: 0 }
+      entry.total += 1
+      if (COMPLETED_STATUSES.includes(normalized)) {
+        entry.completed += 1
+      }
+      grouped.set(task.project_id, entry)
+    })
+
+    await Promise.all(
+      projectsWithProgress.map(async (project) => {
+        const entry = grouped.get(project.id) ?? { total: 0, completed: 0 }
+        const progress = entry.total === 0 ? 0 : Math.round((entry.completed / entry.total) * 100)
+        if (project.progress !== progress) {
+          await supabase
+            .from('projects')
+            .update({ progress })
+            .eq('id', project.id)
+            .eq('user_id', session.user.id)
+        }
+        project.progress = progress
+      })
+    )
+  }
+
+  return NextResponse.json(projectsWithProgress)
 }
 
 export async function POST(request: Request) {
@@ -42,7 +83,7 @@ export async function POST(request: Request) {
     title: body.title,
     description: body.description,
     progress: body.progress ?? 0,
-    due_date: body.due_date,
+    due_date: body.due_date ? body.due_date : null,
     user_id: session.user.id
   }
 

--- a/app/api/revisions/route.ts
+++ b/app/api/revisions/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server'
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs'
+import { cookies } from 'next/headers'
+import { Database } from '@/lib/supabase-types'
+
+export async function GET() {
+  const supabase = createRouteHandlerClient<Database>({ cookies })
+  const {
+    data: { session }
+  } = await supabase.auth.getSession()
+
+  if (!session) {
+    return NextResponse.json({ error: 'Yetkisiz erişim' }, { status: 401 })
+  }
+
+  const { data, error } = await supabase
+    .from('revisions')
+    .select('id, task_id, description, created_at, user_id, tasks(title), profiles(full_name, email)')
+    .eq('user_id', session.user.id)
+    .order('created_at', { ascending: false })
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  const revisions = (data ?? []).map((revision) => ({
+    id: revision.id,
+    task_id: revision.task_id,
+    description: revision.description,
+    created_at: revision.created_at,
+    user_id: revision.user_id,
+    task_title: (revision.tasks as { title: string } | null)?.title ?? 'Görev',
+    author: {
+      full_name: (revision.profiles as { full_name: string | null } | null)?.full_name ?? null,
+      email: (revision.profiles as { email: string | null } | null)?.email ?? null
+    }
+  }))
+
+  return NextResponse.json(revisions)
+}

--- a/app/api/tasks/[id]/comments/route.ts
+++ b/app/api/tasks/[id]/comments/route.ts
@@ -1,0 +1,106 @@
+import { NextResponse } from 'next/server'
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs'
+import { cookies } from 'next/headers'
+import { Database } from '@/lib/supabase-types'
+import { createRevision } from '../../helpers'
+
+export async function GET(_: Request, { params }: { params: { id: string } }) {
+  const supabase = createRouteHandlerClient<Database>({ cookies })
+  const {
+    data: { session }
+  } = await supabase.auth.getSession()
+
+  if (!session) {
+    return NextResponse.json({ error: 'Yetkisiz erişim' }, { status: 401 })
+  }
+
+  const { data, error } = await supabase
+    .from('comments')
+    .select('id, content, created_at, user_id, profiles(full_name, email)')
+    .eq('task_id', params.id)
+    .order('created_at', { ascending: true })
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  const comments = (data ?? []).map((comment) => ({
+    id: comment.id,
+    task_id: params.id,
+    user_id: comment.user_id,
+    content: comment.content,
+    created_at: comment.created_at,
+    author: {
+      full_name:
+        (comment.profiles as { full_name: string | null } | null)?.full_name ??
+        (comment.user_id === session.user.id
+          ? ((session.user.user_metadata?.full_name as string | null) ?? null)
+          : null),
+      email:
+        (comment.profiles as { email: string | null } | null)?.email ??
+        (comment.user_id === session.user.id ? session.user.email ?? null : null)
+    }
+  }))
+
+  return NextResponse.json(comments)
+}
+
+export async function POST(request: Request, { params }: { params: { id: string } }) {
+  const supabase = createRouteHandlerClient<Database>({ cookies })
+  const body = await request.json()
+  const {
+    data: { session }
+  } = await supabase.auth.getSession()
+
+  if (!session) {
+    return NextResponse.json({ error: 'Yetkisiz erişim' }, { status: 401 })
+  }
+
+  const content = typeof body.content === 'string' ? body.content.trim() : ''
+
+  if (!content) {
+    return NextResponse.json({ error: 'Yorum metni gerekli.' }, { status: 400 })
+  }
+
+  const { data, error } = await supabase
+    .from('comments')
+    .insert({
+      task_id: params.id,
+      user_id: session.user.id,
+      content
+    })
+    .select('id, content, created_at, user_id, profiles(full_name, email)')
+    .single()
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  const description = `Yorum eklendi: "${content.slice(0, 120)}${content.length > 120 ? '…' : ''}"`
+
+  const revision = await createRevision(supabase, {
+    taskId: params.id,
+    userId: session.user.id,
+    description,
+    commentId: data.id
+  })
+
+  const commentResponse = {
+    comment: {
+      id: data.id,
+      task_id: params.id,
+      user_id: session.user.id,
+      content: data.content,
+      created_at: data.created_at,
+      author: {
+        full_name:
+          (data.profiles as { full_name: string | null } | null)?.full_name ??
+          (session.user.user_metadata?.full_name ?? null),
+        email: (data.profiles as { email: string | null } | null)?.email ?? session.user.email ?? null
+      }
+    },
+    revision: revision
+  }
+
+  return NextResponse.json(commentResponse, { status: 201 })
+}

--- a/app/api/tasks/[id]/revisions/route.ts
+++ b/app/api/tasks/[id]/revisions/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server'
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs'
+import { cookies } from 'next/headers'
+import { Database } from '@/lib/supabase-types'
+
+export async function GET(_: Request, { params }: { params: { id: string } }) {
+  const supabase = createRouteHandlerClient<Database>({ cookies })
+  const {
+    data: { session }
+  } = await supabase.auth.getSession()
+
+  if (!session) {
+    return NextResponse.json({ error: 'Yetkisiz erişim' }, { status: 401 })
+  }
+
+  const { data, error } = await supabase
+    .from('revisions')
+    .select('id, description, created_at, user_id, comment_id, profiles(full_name, email)')
+    .eq('task_id', params.id)
+    .order('created_at', { ascending: false })
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  const revisions = (data ?? []).map((revision) => ({
+    id: revision.id,
+    task_id: params.id,
+    user_id: revision.user_id,
+    comment_id: revision.comment_id,
+    description: revision.description,
+    created_at: revision.created_at,
+    author: {
+      full_name: (revision.profiles as { full_name: string | null } | null)?.full_name ?? null,
+      email: (revision.profiles as { email: string | null } | null)?.email ?? null
+    }
+  }))
+
+  return NextResponse.json(revisions)
+}

--- a/app/api/tasks/[id]/route.ts
+++ b/app/api/tasks/[id]/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from 'next/server'
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs'
 import { cookies } from 'next/headers'
 import { Database } from '@/lib/supabase-types'
+import { updateProjectProgress, createStatusRevision } from '../helpers'
+import { TaskStatus } from '@/lib/types'
 
 export async function PUT(request: Request, { params }: { params: { id: string } }) {
   const supabase = createRouteHandlerClient<Database>({ cookies })
@@ -15,24 +17,55 @@ export async function PUT(request: Request, { params }: { params: { id: string }
     return NextResponse.json({ error: 'Yetkisiz erişim' }, { status: 401 })
   }
 
-  const { error } = await supabase
+  const { data: existingTask, error: existingError } = await supabase
     .from('tasks')
-    .update({
-      title: body.title,
-      description: body.description,
-      status: body.status,
-      priority: body.priority,
-      due_date: body.due_date,
-      project_id: body.project_id
-    })
+    .select('id, title, description, status, priority, due_date, project_id')
     .eq('id', params.id)
     .eq('user_id', session.user.id)
+    .single()
+
+  if (existingError) {
+    return NextResponse.json({ error: existingError.message }, { status: 404 })
+  }
+
+  const updatePayload: Database['public']['Tables']['tasks']['Update'] = {}
+
+  if ('title' in body) updatePayload.title = body.title
+  if ('description' in body) updatePayload.description = body.description
+  if ('status' in body) updatePayload.status = body.status
+  if ('priority' in body) updatePayload.priority = body.priority
+  if ('due_date' in body) updatePayload.due_date = body.due_date ? body.due_date : null
+  if ('project_id' in body) updatePayload.project_id = body.project_id || null
+
+  const { data, error } = await supabase
+    .from('tasks')
+    .update(updatePayload)
+    .eq('id', params.id)
+    .eq('user_id', session.user.id)
+    .select('*')
+    .single()
 
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 })
   }
 
-  return NextResponse.json({ success: true })
+  if ('status' in body) {
+    await createStatusRevision(supabase, {
+      taskId: params.id,
+      userId: session.user.id,
+      fromStatus: existingTask.status as TaskStatus,
+      toStatus: data.status as TaskStatus
+    })
+  }
+
+  if ('project_id' in body && body.project_id !== existingTask.project_id) {
+    await updateProjectProgress(supabase, existingTask.project_id, session.user.id)
+    await updateProjectProgress(supabase, body.project_id ?? null, session.user.id)
+  } else if ('status' in body && (existingTask.project_id || data.project_id)) {
+    await updateProjectProgress(supabase, data.project_id ?? existingTask.project_id, session.user.id)
+  }
+
+  return NextResponse.json(data)
 }
 
 export async function DELETE(_: Request, { params }: { params: { id: string } }) {
@@ -45,10 +78,21 @@ export async function DELETE(_: Request, { params }: { params: { id: string } })
     return NextResponse.json({ error: 'Yetkisiz erişim' }, { status: 401 })
   }
 
+  const { data: existingTask } = await supabase
+    .from('tasks')
+    .select('project_id')
+    .eq('id', params.id)
+    .eq('user_id', session.user.id)
+    .single()
+
   const { error } = await supabase.from('tasks').delete().eq('id', params.id).eq('user_id', session.user.id)
 
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  if (existingTask?.project_id) {
+    await updateProjectProgress(supabase, existingTask.project_id, session.user.id)
   }
 
   return NextResponse.json({ success: true })

--- a/app/api/tasks/helpers.ts
+++ b/app/api/tasks/helpers.ts
@@ -1,0 +1,84 @@
+import { SupabaseClient } from '@supabase/supabase-js'
+import { Database } from '@/lib/supabase-types'
+import { COMPLETED_STATUSES, getStatusLabel, normalizeStatus } from '@/lib/task-status'
+import { TaskStatus } from '@/lib/types'
+
+type Supabase = SupabaseClient<Database>
+
+export async function updateProjectProgress(supabase: Supabase, projectId: string | null, userId: string) {
+  if (!projectId) return
+
+  const { data: projectTasks } = await supabase
+    .from('tasks')
+    .select('status')
+    .eq('project_id', projectId)
+    .eq('user_id', userId)
+
+  if (!projectTasks) return
+
+  const total = projectTasks.length
+  const completed = projectTasks.filter((task) =>
+    COMPLETED_STATUSES.includes(normalizeStatus(task.status as TaskStatus))
+  ).length
+  const progress = total === 0 ? 0 : Math.round((completed / total) * 100)
+
+  await supabase.from('projects').update({ progress }).eq('id', projectId).eq('user_id', userId)
+}
+
+export async function createRevision(
+  supabase: Supabase,
+  {
+    taskId,
+    userId,
+    description,
+    commentId
+  }: { taskId: string; userId: string; description: string; commentId?: string | null }
+) {
+  const { data } = await supabase
+    .from('revisions')
+    .insert({
+      task_id: taskId,
+      user_id: userId,
+      description,
+      comment_id: commentId ?? null
+    })
+    .select('id, task_id, user_id, comment_id, description, created_at, profiles(full_name, email)')
+    .single()
+
+  if (!data) return null
+
+  const { profiles, ...rest } = data
+
+  return {
+    ...rest,
+    author: {
+      full_name: (profiles as { full_name: string | null } | null)?.full_name ?? null,
+      email: (profiles as { email: string | null } | null)?.email ?? null
+    }
+  }
+}
+
+export async function createStatusRevision(
+  supabase: Supabase,
+  {
+    taskId,
+    userId,
+    fromStatus,
+    toStatus
+  }: { taskId: string; userId: string; fromStatus: TaskStatus | null; toStatus: TaskStatus }
+) {
+  const normalizedFrom = fromStatus ? normalizeStatus(fromStatus) : null
+  const normalizedTo = normalizeStatus(toStatus)
+
+  if (normalizedFrom === normalizedTo) return
+
+  const description = `Durum ${normalizedFrom ? getStatusLabel(normalizedFrom) : 'Belirsiz'} aşamasından ${getStatusLabel(
+    normalizedTo
+  )} aşamasına güncellendi.`
+
+  await createRevision(supabase, {
+    taskId,
+    userId,
+    description
+  })
+}

--- a/app/api/tasks/route.ts
+++ b/app/api/tasks/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs'
 import { cookies } from 'next/headers'
 import { Database } from '@/lib/supabase-types'
+import { updateProjectProgress } from './helpers'
 
 export async function GET() {
   const supabase = createRouteHandlerClient<Database>({ cookies })
@@ -43,8 +44,8 @@ export async function POST(request: Request) {
     description: body.description,
     status: body.status ?? 'todo',
     priority: body.priority ?? 'medium',
-    due_date: body.due_date,
-    project_id: body.project_id,
+    due_date: body.due_date ? body.due_date : null,
+    project_id: body.project_id || null,
     user_id: session.user.id
   }
 
@@ -53,6 +54,8 @@ export async function POST(request: Request) {
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 })
   }
+
+  await updateProjectProgress(supabase, body.project_id ?? null, session.user.id)
 
   return NextResponse.json(data, { status: 201 })
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter } from 'next/font/google'
 import { ReactNode } from 'react'
 import SupabaseProvider from '@/components/providers/supabase-provider'
 import { ThemeProvider } from '@/components/providers/theme-provider'
+import { ToastProvider } from '@/components/providers/toast-provider'
 import { createServerComponentClient } from '@supabase/auth-helpers-nextjs'
 import { cookies } from 'next/headers'
 import { Database } from '@/lib/supabase-types'
@@ -24,11 +25,27 @@ export default async function RootLayout({ children }: RootLayoutProps) {
     data: { session }
   } = await supabase.auth.getSession()
 
+  let initialTheme: 'light' | 'dark' = 'light'
+
+  if (session?.user) {
+    const { data: profile } = await supabase
+      .from('profiles')
+      .select('theme')
+      .eq('id', session.user.id)
+      .single()
+
+    if (profile?.theme === 'dark') {
+      initialTheme = 'dark'
+    }
+  }
+
   return (
     <html lang="tr">
       <body className={`${inter.className} bg-muted`}>
         <SupabaseProvider session={session}>
-          <ThemeProvider>{children}</ThemeProvider>
+          <ThemeProvider initialTheme={initialTheme}>
+            <ToastProvider>{children}</ToastProvider>
+          </ThemeProvider>
         </SupabaseProvider>
       </body>
     </html>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation'
+
+export default function LoginRedirectPage() {
+  redirect('/auth/login')
+}

--- a/components/admin/access-denied.tsx
+++ b/components/admin/access-denied.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import Link from 'next/link'
+import { cn } from '@/lib/utils'
+
+interface AccessDeniedProps {
+  fullName: string
+}
+
+export function AccessDenied({ fullName }: AccessDeniedProps) {
+  return (
+    <div className="space-y-6 rounded-3xl border border-red-100 bg-red-50 p-8 text-red-700 shadow-sm">
+      <div>
+        <p className="text-sm font-semibold uppercase tracking-wide">Erişim Engellendi</p>
+        <h2 className="mt-2 text-2xl font-semibold text-red-800">Merhaba {fullName}, bu alana erişimin yok.</h2>
+        <p className="mt-3 text-sm text-red-600">
+          Yönetim paneli sadece yönetici yetkisine sahip kullanıcılarla sınırlıdır. Görev ve projelerini görüntülemek için
+          gösterge paneline dönebilirsin.
+        </p>
+      </div>
+      <Link
+        href="/dashboard"
+        className={cn(
+          'inline-flex items-center justify-center rounded-lg bg-accent px-4 py-2 text-sm font-medium text-white transition hover:opacity-90'
+        )}
+      >
+        Gösterge Paneline Dön
+      </Link>
+    </div>
+  )
+}

--- a/components/admin/admin-panel.tsx
+++ b/components/admin/admin-panel.tsx
@@ -1,0 +1,204 @@
+import Link from 'next/link'
+import { Project, Task, Goal } from '@/lib/types'
+import { COMPLETED_STATUSES, TASK_STATUS_ORDER, getStatusLabel } from '@/lib/task-status'
+import { formatDate, formatDateTime } from '@/lib/utils'
+import { Badge } from '@/components/ui/badge'
+
+type RevisionActivity = {
+  id: string
+  task_id: string
+  description: string
+  created_at: string
+  user_id: string
+  task_title: string
+  author?: {
+    full_name: string | null
+    email: string | null
+  } | null
+}
+
+interface AdminPanelProps {
+  tasks: Task[]
+  projects: Project[]
+  goals: Goal[]
+  revisions: RevisionActivity[]
+}
+
+export function AdminPanel({ tasks, projects, goals, revisions }: AdminPanelProps) {
+  const totalTasks = tasks.length
+  const completedTasks = tasks.filter((task) => COMPLETED_STATUSES.includes(task.status)).length
+  const reviewTasks = tasks.filter((task) => task.status === 'in_review').length
+  const revisionTasks = tasks.filter((task) => task.status === 'revision').length
+  const activeProjects = projects.filter((project) => project.progress < 100).length
+  const completedGoals = goals.filter((goal) => goal.is_completed).length
+  const goalCompletionRate = goals.length === 0 ? 0 : Math.round((completedGoals / goals.length) * 100)
+  const averageProjectProgress = projects.length === 0
+    ? 0
+    : Math.round(projects.reduce((sum, project) => sum + project.progress, 0) / projects.length)
+
+  const statusBreakdown = TASK_STATUS_ORDER.map((status) => ({
+    status,
+    count: tasks.filter((task) => task.status === status).length
+  }))
+
+  const upcomingTasks = tasks
+    .filter((task) => task.due_date)
+    .sort((a, b) => new Date(a.due_date ?? '').getTime() - new Date(b.due_date ?? '').getTime())
+    .slice(0, 5)
+
+  const latestRevisions = revisions.slice(0, 8)
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-3xl bg-white p-8 shadow-sm">
+        <h1 className="text-2xl font-semibold text-gray-900">Yönetim Paneli</h1>
+        <p className="mt-2 text-sm text-gray-500">Görev, proje ve hedeflerinize ait en güncel özet.</p>
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+        <StatCard label="Toplam Görev" value={totalTasks} description="Tüm durumlar" />
+        <StatCard label="Tamamlanan" value={completedTasks} description="Teslim edilen görevler" />
+        <StatCard
+          label="İnceleme / Revize"
+          value={reviewTasks + revisionTasks}
+          description="Onay bekleyen görevler"
+        />
+        <StatCard label="Aktif Proje" value={activeProjects} description="%100 tamamlanmamış" />
+      </div>
+
+      <div className="grid gap-6 xl:grid-cols-3">
+        <div className="space-y-4 rounded-3xl border border-gray-200 bg-white p-6 xl:col-span-2">
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="text-lg font-semibold text-gray-900">Durum Dağılımı</h2>
+              <p className="text-sm text-gray-500">Görevlerin mevcut aşamalara göre dağılımı.</p>
+            </div>
+            <Link href="/tasks" className="text-sm font-medium text-accent hover:underline">
+              Görevleri Yönet
+            </Link>
+          </div>
+          <div className="grid gap-3 md:grid-cols-2">
+            {statusBreakdown.map(({ status, count }) => (
+              <div key={status} className="rounded-2xl border border-gray-200 bg-gray-50 p-4">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-semibold text-gray-900">{getStatusLabel(status)}</span>
+                  <Badge color={count > 0 ? 'orange' : 'gray'}>{count} görev</Badge>
+                </div>
+                <p className="mt-2 text-xs text-gray-500">
+                  {count === 0 ? 'Bu aşamada görev bulunmuyor.' : 'Güncel olarak bu aşamada bekleyen görevler.'}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="space-y-4 rounded-3xl border border-gray-200 bg-white p-6">
+          <h2 className="text-lg font-semibold text-gray-900">Hedef İlerlemesi</h2>
+          <p className="text-sm text-gray-500">Tamamlanan {completedGoals} / {goals.length} hedef</p>
+          <div className="h-2 w-full rounded-full bg-gray-100">
+            <div className="h-2 rounded-full bg-accent" style={{ width: `${goalCompletionRate}%` }}></div>
+          </div>
+          <p className="text-sm font-semibold text-accent">%{goalCompletionRate}</p>
+          <div className="rounded-2xl bg-gray-50 p-4 text-sm text-gray-600">
+            <p className="font-semibold text-gray-900">Proje Ortalama İlerlemesi</p>
+            <p className="mt-1 text-2xl font-bold text-accent">%{averageProjectProgress}</p>
+            <p className="text-xs text-gray-500">Tüm projelerin mevcut durumlarına göre ortalama.</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <div className="space-y-4 rounded-3xl border border-gray-200 bg-white p-6">
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="text-lg font-semibold text-gray-900">Yaklaşan Görevler</h2>
+              <p className="text-sm text-gray-500">Teslim tarihi yaklaşan en güncel görevler.</p>
+            </div>
+            <Link href="/calendar" className="text-sm font-medium text-accent hover:underline">
+              Takvimde Gör
+            </Link>
+          </div>
+          {upcomingTasks.length === 0 ? (
+            <p className="text-sm text-gray-500">Yaklaşan görev bulunmuyor. Yeni görev ekleyerek plan oluşturun.</p>
+          ) : (
+            <div className="space-y-3">
+              {upcomingTasks.map((task) => (
+                <div key={task.id} className="rounded-2xl border border-gray-200 p-4">
+                  <div className="flex items-center justify-between text-xs text-gray-500">
+                    <span className="font-semibold text-gray-900">{task.title}</span>
+                    <Badge color="gray">{formatDate(task.due_date)}</Badge>
+                  </div>
+                  <p className="mt-1 text-sm text-gray-600">{task.description ?? 'Açıklama bulunmuyor.'}</p>
+                  <p className="mt-2 text-xs text-accent">Durum: {getStatusLabel(task.status)}</p>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="space-y-4 rounded-3xl border border-gray-200 bg-white p-6">
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="text-lg font-semibold text-gray-900">Projeler</h2>
+              <p className="text-sm text-gray-500">Aktif projelerin genel görünümü.</p>
+            </div>
+            <Link href="/projects" className="text-sm font-medium text-accent hover:underline">
+              Projeleri Aç
+            </Link>
+          </div>
+          {projects.length === 0 ? (
+            <p className="text-sm text-gray-500">Henüz proje oluşturulmadı. Yeni bir proje ekleyin.</p>
+          ) : (
+            <div className="space-y-3">
+              {projects.map((project) => (
+                <div key={project.id} className="space-y-2 rounded-2xl border border-gray-200 p-4">
+                  <div className="flex items-center justify-between">
+                    <p className="text-sm font-semibold text-gray-900">{project.title}</p>
+                    <span className="text-xs text-gray-500">Teslim: {formatDate(project.due_date)}</span>
+                  </div>
+                  <p className="text-xs text-gray-500">{project.description ?? 'Açıklama bulunmuyor.'}</p>
+                  <div className="h-2 w-full rounded-full bg-gray-100">
+                    <div className="h-2 rounded-full bg-accent" style={{ width: `${project.progress}%` }}></div>
+                  </div>
+                  <p className="text-xs font-semibold text-accent">%{project.progress}</p>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="space-y-4 rounded-3xl border border-gray-200 bg-white p-6">
+        <h2 className="text-lg font-semibold text-gray-900">Son Revizyonlar</h2>
+        {latestRevisions.length === 0 ? (
+          <p className="text-sm text-gray-500">Henüz revizyon kaydı bulunmuyor.</p>
+        ) : (
+          <div className="space-y-3">
+            {latestRevisions.map((revision) => (
+              <div key={revision.id} className="rounded-2xl border border-gray-200 bg-gray-50 p-4">
+                <div className="flex items-center justify-between text-xs text-gray-500">
+                  <span className="font-semibold text-gray-900">{revision.task_title}</span>
+                  <span>{formatDateTime(revision.created_at)}</span>
+                </div>
+                <p className="mt-1 text-xs text-gray-500">
+                  {revision.author?.full_name ?? revision.author?.email ?? 'Kullanıcı'}
+                </p>
+                <p className="mt-2 text-sm text-gray-700">{revision.description}</p>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function StatCard({ label, value, description }: { label: string; value: number; description: string }) {
+  return (
+    <div className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm">
+      <p className="text-sm font-medium text-gray-500">{label}</p>
+      <p className="mt-3 text-3xl font-semibold text-gray-900">{value}</p>
+      <p className="mt-2 text-xs text-gray-500">{description}</p>
+    </div>
+  )
+}

--- a/components/goals/goal-form.tsx
+++ b/components/goals/goal-form.tsx
@@ -1,0 +1,92 @@
+'use client'
+
+import { FormEvent, useState } from 'react'
+import { Goal } from '@/lib/types'
+import { Button } from '@/components/ui/button'
+import { useToast } from '@/components/providers/toast-provider'
+
+interface GoalFormProps {
+  onSuccess: (goal: Goal) => void
+  initialData?: Goal
+}
+
+export function GoalForm({ onSuccess, initialData }: GoalFormProps) {
+  const [title, setTitle] = useState(initialData?.title ?? '')
+  const [description, setDescription] = useState(initialData?.description ?? '')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const { toast } = useToast()
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault()
+    const trimmedTitle = title.trim()
+    if (!trimmedTitle) {
+      setError('Hedef başlığı gerekli')
+      toast({ title: 'İşlem başarısız', description: 'Hedef başlığı gerekli.', variant: 'error' })
+      return
+    }
+
+    setLoading(true)
+    setError(null)
+
+    const payload = {
+      title: trimmedTitle,
+      description: description.trim() ? description.trim() : null
+    }
+
+    try {
+      const response = await fetch(initialData ? `/api/goals/${initialData.id}` : '/api/goals', {
+        method: initialData ? 'PUT' : 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(payload)
+      })
+
+      if (!response.ok) {
+        const data = await response.json()
+        setError(data.error ?? 'Bir hata oluştu')
+        toast({ title: 'İşlem başarısız', description: data.error ?? 'Hedef kaydedilemedi.', variant: 'error' })
+        return
+      }
+
+      const data = (await response.json()) as Goal
+
+      toast({
+        title: initialData ? 'Hedef güncellendi' : 'Hedef oluşturuldu',
+        description: initialData ? 'Hedef detayları kaydedildi.' : 'Yeni hedef başarıyla eklendi.',
+        variant: 'success'
+      })
+
+      onSuccess(data)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Hedef kaydedilemedi.'
+      setError(message)
+      toast({ title: 'İşlem başarısız', description: message, variant: 'error' })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label className="text-sm font-medium text-gray-700">Hedef Başlığı</label>
+        <input value={title} onChange={(event) => setTitle(event.target.value)} placeholder="Örn. Haftalık raporu tamamla" required />
+      </div>
+      <div>
+        <label className="text-sm font-medium text-gray-700">Açıklama</label>
+        <textarea
+          value={description}
+          onChange={(event) => setDescription(event.target.value)}
+          rows={3}
+          placeholder="Hedefin detaylarını paylaşın"
+        ></textarea>
+      </div>
+      {error && <p className="text-sm text-red-500">{error}</p>}
+      <Button type="submit" className="w-full" disabled={loading}>
+        {loading ? 'Kaydediliyor...' : initialData ? 'Hedefi Güncelle' : 'Hedef Oluştur'}
+      </Button>
+    </form>
+  )
+}

--- a/components/goals/goals-client.tsx
+++ b/components/goals/goals-client.tsx
@@ -1,0 +1,191 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { Goal } from '@/lib/types'
+import { Button } from '@/components/ui/button'
+import { Modal } from '@/components/ui/modal'
+import { GoalForm } from './goal-form'
+import { useToast } from '@/components/providers/toast-provider'
+
+interface GoalsClientProps {
+  initialGoals: Goal[]
+}
+
+export function GoalsClient({ initialGoals }: GoalsClientProps) {
+  const [goals, setGoals] = useState<Goal[]>(initialGoals)
+  const [isModalOpen, setIsModalOpen] = useState(false)
+  const [editingGoal, setEditingGoal] = useState<Goal | null>(null)
+  const { toast } = useToast()
+
+  useEffect(() => {
+    setGoals(initialGoals)
+  }, [initialGoals])
+
+  const progress = useMemo(() => {
+    if (goals.length === 0) return 0
+    const completed = goals.filter((goal) => goal.is_completed).length
+    return Math.round((completed / goals.length) * 100)
+  }, [goals])
+
+  const refreshGoals = async () => {
+    try {
+      const response = await fetch('/api/goals')
+      if (!response.ok) {
+        const data = await response.json()
+        toast({ title: 'Hedefler yenilenemedi', description: data.error ?? 'Bir hata oluştu.', variant: 'error' })
+        return
+      }
+      const data = (await response.json()) as Goal[]
+      setGoals(data)
+    } catch (error) {
+      toast({
+        title: 'Hedefler yenilenemedi',
+        description: error instanceof Error ? error.message : 'Bir hata oluştu.',
+        variant: 'error'
+      })
+    }
+  }
+
+  const handleToggle = async (goal: Goal) => {
+    try {
+      const response = await fetch(`/api/goals/${goal.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ is_completed: !goal.is_completed })
+      })
+
+      if (!response.ok) {
+        const data = await response.json()
+        toast({ title: 'Hedef güncellenemedi', description: data.error ?? 'Bir hata oluştu.', variant: 'error' })
+        return
+      }
+
+      const updated = (await response.json()) as Goal
+      setGoals((prev) => prev.map((item) => (item.id === updated.id ? updated : item)))
+      toast({
+        title: updated.is_completed ? 'Hedef tamamlandı' : 'Hedef güncellendi',
+        description: updated.is_completed
+          ? 'Harika! Bu hedef tamamlandı olarak işaretlendi.'
+          : 'Hedef yeniden planlandı.',
+        variant: 'success'
+      })
+    } catch (error) {
+      toast({
+        title: 'Hedef güncellenemedi',
+        description: error instanceof Error ? error.message : 'Bir hata oluştu.',
+        variant: 'error'
+      })
+    }
+  }
+
+  const handleDelete = async (goal: Goal) => {
+    try {
+      const response = await fetch(`/api/goals/${goal.id}`, { method: 'DELETE' })
+      if (!response.ok) {
+        const data = await response.json()
+        toast({ title: 'Hedef silinemedi', description: data.error ?? 'Bir hata oluştu.', variant: 'error' })
+        return
+      }
+      toast({ title: 'Hedef silindi', description: 'Hedef listeden kaldırıldı.', variant: 'success' })
+      setGoals((prev) => prev.filter((item) => item.id !== goal.id))
+    } catch (error) {
+      toast({
+        title: 'Hedef silinemedi',
+        description: error instanceof Error ? error.message : 'Bir hata oluştu.',
+        variant: 'error'
+      })
+    }
+  }
+
+  const openCreateModal = () => {
+    setEditingGoal(null)
+    setIsModalOpen(true)
+  }
+
+  const openEditModal = (goal: Goal) => {
+    setEditingGoal(goal)
+    setIsModalOpen(true)
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900">Hedefler</h1>
+          <p className="text-sm text-gray-500">Ekip hedeflerinizi planlayın ve ilerlemenizi takip edin.</p>
+        </div>
+        <Button onClick={openCreateModal}>+ Yeni Hedef</Button>
+      </div>
+
+      <div className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm">
+        <div className="mb-4 flex items-center justify-between">
+          <div>
+            <p className="text-sm font-semibold text-gray-900">Genel İlerleme</p>
+            <p className="text-xs text-gray-500">Tamamlanan hedef yüzdesi</p>
+          </div>
+          <span className="text-sm font-semibold text-accent">%{progress}</span>
+        </div>
+        <div className="h-2 w-full rounded-full bg-gray-100">
+          <div className="h-2 rounded-full bg-accent" style={{ width: `${progress}%` }}></div>
+        </div>
+      </div>
+
+      {goals.length === 0 ? (
+        <div className="rounded-3xl border border-dashed border-gray-300 bg-white p-12 text-center text-sm text-gray-500">
+          Henüz hedef oluşturulmadı. İlk hedefinizi ekleyerek ekibinizi motive edin.
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {goals.map((goal) => (
+            <div key={goal.id} className="flex flex-col gap-3 rounded-3xl border border-gray-200 bg-white p-4 shadow-sm sm:flex-row sm:items-center sm:justify-between">
+              <label className="flex flex-1 items-start gap-3">
+                <input
+                  type="checkbox"
+                  checked={goal.is_completed}
+                  onChange={() => handleToggle(goal)}
+                  className="mt-1 h-5 w-5 rounded border-gray-300 text-accent focus:ring-accent"
+                />
+                <div>
+                  <p className="text-sm font-semibold text-gray-900">{goal.title}</p>
+                  {goal.description && <p className="mt-1 text-xs text-gray-500">{goal.description}</p>}
+                </div>
+              </label>
+              <div className="flex items-center gap-2 self-end sm:self-auto">
+                <Button variant="secondary" onClick={() => openEditModal(goal)}>
+                  Düzenle
+                </Button>
+                <Button variant="ghost" className="text-red-500" onClick={() => handleDelete(goal)}>
+                  Sil
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <Modal
+        isOpen={isModalOpen}
+        onClose={() => {
+          setIsModalOpen(false)
+        }}
+        title={editingGoal ? 'Hedefi Düzenle' : 'Yeni Hedef Oluştur'}
+      >
+        <GoalForm
+          initialData={editingGoal ?? undefined}
+          onSuccess={(goal) => {
+            setIsModalOpen(false)
+            setEditingGoal(null)
+            setGoals((prev) => {
+              const exists = prev.some((item) => item.id === goal.id)
+              if (exists) {
+                return prev.map((item) => (item.id === goal.id ? goal : item))
+              }
+              return [...prev, goal]
+            })
+            refreshGoals()
+          }}
+        />
+      </Modal>
+    </div>
+  )
+}

--- a/components/layout/dashboard-shell.tsx
+++ b/components/layout/dashboard-shell.tsx
@@ -7,13 +7,14 @@ interface DashboardShellProps {
   user: {
     full_name: string | null
     email: string
+    role: 'admin' | 'user'
   }
 }
 
 export default function DashboardShell({ children, user }: DashboardShellProps) {
   return (
     <div className="flex min-h-screen bg-muted">
-      <Sidebar />
+      <Sidebar role={user.role} />
       <div className="flex flex-1 flex-col">
         <Topbar fullName={user.full_name} email={user.email} />
         <main className="flex-1 overflow-y-auto bg-muted p-8">

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -2,18 +2,31 @@
 
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { LayoutDashboard, FolderKanban, ListTodo, CalendarDays, Settings } from 'lucide-react'
+import { LayoutDashboard, FolderKanban, ListTodo, CalendarDays, Settings, Target, ShieldCheck } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
-const navItems = [
+type NavItem = {
+  name: string
+  href: string
+  icon: typeof LayoutDashboard
+  adminOnly?: boolean
+}
+
+const navItems: NavItem[] = [
   { name: 'Gösterge Paneli', href: '/dashboard', icon: LayoutDashboard },
   { name: 'Projeler', href: '/projects', icon: FolderKanban },
   { name: 'Görevler', href: '/tasks', icon: ListTodo },
+  { name: 'Hedefler', href: '/goals', icon: Target },
   { name: 'Takvim', href: '/calendar', icon: CalendarDays },
-  { name: 'Ayarlar', href: '/settings', icon: Settings }
+  { name: 'Ayarlar', href: '/settings', icon: Settings },
+  { name: 'Yönetim', href: '/admin', icon: ShieldCheck, adminOnly: true }
 ]
 
-export default function Sidebar() {
+interface SidebarProps {
+  role: 'admin' | 'user'
+}
+
+export default function Sidebar({ role }: SidebarProps) {
   const pathname = usePathname()
 
   return (
@@ -26,7 +39,9 @@ export default function Sidebar() {
         </div>
       </div>
       <nav className="flex flex-1 flex-col gap-1">
-        {navItems.map((item) => {
+        {navItems
+          .filter((item) => (item.adminOnly ? role === 'admin' : true))
+          .map((item) => {
           const Icon = item.icon
           const isActive = pathname === item.href || pathname?.startsWith(item.href + '/')
           return (

--- a/components/projects/project-form.tsx
+++ b/components/projects/project-form.tsx
@@ -3,10 +3,11 @@
 import { useState, FormEvent } from 'react'
 import { Project } from '@/lib/types'
 import { Button } from '@/components/ui/button'
+import { useToast } from '@/components/providers/toast-provider'
 
 interface ProjectFormProps {
   initialData?: Project
-  onSuccess: () => void
+  onSuccess: (project: Project) => void
 }
 
 export function ProjectForm({ initialData, onSuccess }: ProjectFormProps) {
@@ -16,36 +17,61 @@ export function ProjectForm({ initialData, onSuccess }: ProjectFormProps) {
   const [dueDate, setDueDate] = useState(initialData?.due_date?.slice(0, 10) ?? '')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const { toast } = useToast()
 
   const handleSubmit = async (event: FormEvent) => {
     event.preventDefault()
+    const trimmedTitle = title.trim()
+    if (!trimmedTitle) {
+      setError('Proje başlığı gerekli')
+      toast({ title: 'İşlem başarısız', description: 'Proje başlığı gerekli.', variant: 'error' })
+      return
+    }
+
     setLoading(true)
     setError(null)
 
     const payload = {
-      title,
-      description,
+      title: trimmedTitle,
+      description: description?.trim() ? description.trim() : null,
       progress,
-      due_date: dueDate
+      due_date: dueDate ? dueDate : null
     }
 
-    const response = await fetch(initialData ? `/api/projects/${initialData.id}` : '/api/projects', {
-      method: initialData ? 'PUT' : 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify(payload)
-    })
+    try {
+      const response = await fetch(initialData ? `/api/projects/${initialData.id}` : '/api/projects', {
+        method: initialData ? 'PUT' : 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(payload)
+      })
 
-    setLoading(false)
+      if (!response.ok) {
+        const data = await response.json()
+        setError(data.error ?? 'Bir hata oluştu')
+        toast({ title: 'İşlem başarısız', description: data.error ?? 'Proje kaydedilemedi.', variant: 'error' })
+        return
+      }
 
-    if (!response.ok) {
-      const data = await response.json()
-      setError(data.error ?? 'Bir hata oluştu')
-      return
+      const data = (await response.json()) as Project
+
+      toast({
+        title: initialData ? 'Proje güncellendi' : 'Proje oluşturuldu',
+        description: initialData
+          ? 'Proje detayları başarıyla güncellendi.'
+          : 'Yeni projeniz yönetim paneline eklendi.',
+        variant: 'success'
+      })
+
+      onSuccess(data)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Proje kaydedilemedi.'
+      setError(message)
+      toast({ title: 'İşlem başarısız', description: message, variant: 'error' })
+    } finally {
+      setLoading(false)
     }
-
-    onSuccess()
   }
 
   return (
@@ -61,7 +87,8 @@ export function ProjectForm({ initialData, onSuccess }: ProjectFormProps) {
       <div className="grid grid-cols-2 gap-4">
         <div>
           <label className="text-sm font-medium text-gray-700">İlerleme (%)</label>
-          <input type="number" min={0} max={100} value={progress} onChange={(e) => setProgress(Number(e.target.value))} />
+          <input type="number" min={0} max={100} value={progress} readOnly />
+          <p className="mt-1 text-xs text-gray-500">Görev tamamlama durumuna göre otomatik hesaplanır.</p>
         </div>
         <div>
           <label className="text-sm font-medium text-gray-700">Teslim Tarihi</label>

--- a/components/providers/toast-provider.tsx
+++ b/components/providers/toast-provider.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+import { createContext, ReactNode, useCallback, useContext, useMemo, useState } from 'react'
+
+export type ToastVariant = 'default' | 'success' | 'error'
+
+type ToastMessage = {
+  id: string
+  title: string
+  description?: string
+  variant: ToastVariant
+}
+
+type ToastContextValue = {
+  toast: (toast: Omit<ToastMessage, 'id'> & { id?: string }) => void
+}
+
+const ToastContext = createContext<ToastContextValue | undefined>(undefined)
+
+const createId = () =>
+  typeof crypto !== 'undefined' && 'randomUUID' in crypto
+    ? crypto.randomUUID()
+    : Math.random().toString(36).slice(2)
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<ToastMessage[]>([])
+
+  const removeToast = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((toast) => toast.id !== id))
+  }, [])
+
+  const pushToast = useCallback(
+    (toast: Omit<ToastMessage, 'id'> & { id?: string }) => {
+      const id = toast.id ?? createId()
+      const nextToast: ToastMessage = {
+        id,
+        title: toast.title,
+        description: toast.description,
+        variant: toast.variant ?? 'default'
+      }
+      setToasts((prev) => [...prev, nextToast])
+      window.setTimeout(() => removeToast(id), 4000)
+    },
+    [removeToast]
+  )
+
+  const value = useMemo(() => ({ toast: pushToast }), [pushToast])
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <div className="pointer-events-none fixed bottom-4 right-4 z-[100] flex w-full max-w-sm flex-col gap-3">
+        {toasts.map((toast) => (
+          <div
+            key={toast.id}
+            className={`pointer-events-auto rounded-2xl border p-4 shadow-lg transition ${
+              toast.variant === 'success'
+                ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
+                : toast.variant === 'error'
+                ? 'border-red-200 bg-red-50 text-red-700'
+                : 'border-gray-200 bg-white text-gray-700'
+            }`}
+          >
+            <p className="text-sm font-semibold">{toast.title}</p>
+            {toast.description && <p className="mt-1 text-xs opacity-80">{toast.description}</p>}
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  )
+}
+
+export function useToast() {
+  const context = useContext(ToastContext)
+  if (!context) {
+    throw new Error('useToast must be used within a ToastProvider')
+  }
+  return context
+}

--- a/components/tasks/kanban-board.tsx
+++ b/components/tasks/kanban-board.tsx
@@ -7,48 +7,76 @@ import { TaskCard } from './task-card'
 import { Modal } from '@/components/ui/modal'
 import { TaskForm } from './task-form'
 import { Button } from '@/components/ui/button'
+import { normalizeStatus, TASK_STATUS_ORDER, getStatusLabel } from '@/lib/task-status'
+import { TaskDetails } from './task-details'
+import { useToast } from '@/components/providers/toast-provider'
 
 interface KanbanBoardProps {
   initialTasks: Task[]
   projects: { id: string; title: string }[]
 }
 
-type ColumnKey = 'todo' | 'in_progress' | 'done'
+type ColumnKey = (typeof TASK_STATUS_ORDER)[number]
 
-const columnTitles: Record<ColumnKey, string> = {
-  todo: 'Yapılacaklar',
-  in_progress: 'Devam Edenler',
-  done: 'Tamamlanan'
-}
+const columnTitles: Record<ColumnKey, string> = TASK_STATUS_ORDER.reduce(
+  (acc, status) => {
+    acc[status] = getStatusLabel(status)
+    return acc
+  },
+  {} as Record<ColumnKey, string>
+)
 
 export function KanbanBoard({ initialTasks, projects }: KanbanBoardProps) {
-  const [tasks, setTasks] = useState<Task[]>(initialTasks)
+  const [tasks, setTasks] = useState<Task[]>(() =>
+    initialTasks.map((task) => ({ ...task, status: normalizeStatus(task.status) }))
+  )
   const [isModalOpen, setIsModalOpen] = useState(false)
+  const [selectedTask, setSelectedTask] = useState<Task | null>(null)
+  const [isDetailsOpen, setIsDetailsOpen] = useState(false)
+  const { toast } = useToast()
 
   const groupedTasks = useMemo(() => {
-    return tasks.reduce(
-      (acc, task) => {
-        acc[task.status].push(task)
+    const initial = TASK_STATUS_ORDER.reduce(
+      (acc, status) => {
+        acc[status] = [] as Task[]
         return acc
       },
-      {
-        todo: [] as Task[],
-        in_progress: [] as Task[],
-        done: [] as Task[]
-      }
+      {} as Record<ColumnKey, Task[]>
     )
+    tasks.forEach((task) => {
+      const normalized = normalizeStatus(task.status)
+      initial[normalized].push({ ...task, status: normalized })
+    })
+    return initial
   }, [tasks])
 
   const refreshTasks = async () => {
-    const response = await fetch('/api/tasks')
-    if (response.ok) {
-      const data = await response.json()
-      setTasks(data)
+    try {
+      const response = await fetch('/api/tasks')
+      if (!response.ok) {
+        const data = await response.json()
+        toast({ title: 'Görevler yenilenemedi', description: data.error ?? 'Bir hata oluştu.', variant: 'error' })
+        return
+      }
+      const data = (await response.json()) as Task[]
+      setTasks(data.map((task) => ({ ...task, status: normalizeStatus(task.status) })))
+      if (selectedTask) {
+        const updated = data.find((item) => item.id === selectedTask.id)
+        if (updated) {
+          setSelectedTask({ ...updated, status: normalizeStatus(updated.status) })
+        }
+      }
+    } catch (error) {
+      toast({
+        title: 'Görevler yenilenemedi',
+        description: error instanceof Error ? error.message : 'Bir hata oluştu.',
+        variant: 'error'
+      })
     }
   }
 
   useEffect(() => {
-    setTasks(initialTasks)
+    setTasks(initialTasks.map((task) => ({ ...task, status: normalizeStatus(task.status) })))
   }, [initialTasks])
 
   const handleDragEnd = async ({ destination, source, draggableId }: DropResult) => {
@@ -56,18 +84,69 @@ export function KanbanBoard({ initialTasks, projects }: KanbanBoardProps) {
     if (destination.droppableId === source.droppableId) return
 
     const newStatus = destination.droppableId as ColumnKey
-    setTasks((prev) => prev.map((task) => (task.id === draggableId ? { ...task, status: newStatus } : task)))
+    const previous = tasks
+    setTasks((prev) =>
+      prev.map((task) => (task.id === draggableId ? { ...task, status: normalizeStatus(newStatus) } : task))
+    )
 
-    await fetch(`/api/tasks/${draggableId}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ status: newStatus })
-    })
-    refreshTasks()
+    try {
+      const response = await fetch(`/api/tasks/${draggableId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: newStatus })
+      })
+
+      if (!response.ok) {
+        const data = await response.json()
+        toast({ title: 'Durum güncellenemedi', description: data.error ?? 'Bir hata oluştu.', variant: 'error' })
+        setTasks(previous)
+        return
+      }
+
+      toast({
+        title: 'Durum güncellendi',
+        description: `${getStatusLabel(newStatus)} aşamasına taşındı.`,
+        variant: 'success'
+      })
+      refreshTasks()
+    } catch (error) {
+      toast({
+        title: 'Durum güncellenemedi',
+        description: error instanceof Error ? error.message : 'Bir hata oluştu.',
+        variant: 'error'
+      })
+      setTasks(previous)
+    }
   }
 
   const handleDelete = async (task: Task) => {
-    await fetch(`/api/tasks/${task.id}`, { method: 'DELETE' })
+    try {
+      const response = await fetch(`/api/tasks/${task.id}`, { method: 'DELETE' })
+      if (!response.ok) {
+        const data = await response.json()
+        toast({ title: 'Görev silinemedi', description: data.error ?? 'Bir hata oluştu.', variant: 'error' })
+        return
+      }
+      toast({ title: 'Görev silindi', description: 'Görev panodan kaldırıldı.', variant: 'success' })
+      refreshTasks()
+    } catch (error) {
+      toast({
+        title: 'Görev silinemedi',
+        description: error instanceof Error ? error.message : 'Bir hata oluştu.',
+        variant: 'error'
+      })
+    }
+  }
+
+  const handleOpenDetails = (task: Task) => {
+    const normalizedTask = { ...task, status: normalizeStatus(task.status) }
+    setSelectedTask(normalizedTask)
+    setIsDetailsOpen(true)
+  }
+
+  const handleTaskUpdated = (updatedTask: Task) => {
+    setTasks((prev) => prev.map((task) => (task.id === updatedTask.id ? updatedTask : task)))
+    setSelectedTask(updatedTask)
     refreshTasks()
   }
 
@@ -99,7 +178,7 @@ export function KanbanBoard({ initialTasks, projects }: KanbanBoardProps) {
                           {...dragProvided.draggableProps}
                           {...dragProvided.dragHandleProps}
                         >
-                          <TaskCard task={task} onDelete={handleDelete} />
+                          <TaskCard task={task} onDelete={handleDelete} onOpen={handleOpenDetails} />
                         </div>
                       )}
                     </Draggable>
@@ -115,11 +194,33 @@ export function KanbanBoard({ initialTasks, projects }: KanbanBoardProps) {
       <Modal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} title="Yeni Görev Oluştur">
         <TaskForm
           projects={projects}
-          onSuccess={() => {
+          onSuccess={(createdTask) => {
             setIsModalOpen(false)
+            setTasks((prev) => [...prev, { ...createdTask, status: normalizeStatus(createdTask.status) }])
             refreshTasks()
           }}
         />
+      </Modal>
+
+      <Modal
+        isOpen={isDetailsOpen && !!selectedTask}
+        onClose={() => {
+          setIsDetailsOpen(false)
+          setSelectedTask(null)
+        }}
+        title="Görev Detayları"
+      >
+        {selectedTask && (
+          <TaskDetails
+            task={selectedTask}
+            projects={projects}
+            onClose={() => {
+              setIsDetailsOpen(false)
+              setSelectedTask(null)
+            }}
+            onTaskUpdated={handleTaskUpdated}
+          />
+        )}
       </Modal>
     </div>
   )

--- a/components/tasks/revision-feed.tsx
+++ b/components/tasks/revision-feed.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { formatDateTime } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import { useToast } from '@/components/providers/toast-provider'
+
+interface RevisionItem {
+  id: string
+  task_id: string
+  description: string
+  created_at: string
+  user_id: string
+  task_title: string
+  author?: {
+    full_name: string | null
+    email: string | null
+  } | null
+}
+
+interface RevisionFeedProps {
+  initialRevisions: RevisionItem[]
+}
+
+export function RevisionFeed({ initialRevisions }: RevisionFeedProps) {
+  const [revisions, setRevisions] = useState<RevisionItem[]>(initialRevisions)
+  const [loading, setLoading] = useState(false)
+  const { toast } = useToast()
+
+  useEffect(() => {
+    setRevisions(initialRevisions)
+  }, [initialRevisions])
+
+  const refresh = async () => {
+    setLoading(true)
+    try {
+      const response = await fetch('/api/revisions')
+      if (!response.ok) {
+        const data = await response.json()
+        toast({
+          title: 'Revize geçmişi yüklenemedi',
+          description: data.error ?? 'Bir hata oluştu.',
+          variant: 'error'
+        })
+        return
+      }
+      const data = (await response.json()) as RevisionItem[]
+      setRevisions(data)
+    } catch (error) {
+      toast({
+        title: 'Revize geçmişi yüklenemedi',
+        description: error instanceof Error ? error.message : 'Bir hata oluştu.',
+        variant: 'error'
+      })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="space-y-4 rounded-3xl border border-gray-200 bg-white p-6 shadow-sm">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-lg font-semibold text-gray-900">Revize Geçmişi</h3>
+          <p className="text-sm text-gray-500">Tüm görevlerde yapılan yorum ve durum güncellemeleri.</p>
+        </div>
+        <Button variant="secondary" onClick={refresh} disabled={loading}>
+          {loading ? 'Yükleniyor...' : 'Yenile'}
+        </Button>
+      </div>
+      {revisions.length === 0 ? (
+        <p className="text-sm text-gray-500">Henüz revize kaydı bulunmuyor.</p>
+      ) : (
+        <div className="space-y-3">
+          {revisions.map((revision) => (
+            <div key={revision.id} className="rounded-2xl border border-gray-200 bg-gray-50 p-4">
+              <div className="flex items-center justify-between text-xs text-gray-500">
+                <span className="font-medium text-gray-700">{revision.task_title}</span>
+                <span>{formatDateTime(revision.created_at)}</span>
+              </div>
+              <p className="mt-1 text-xs text-gray-500">
+                {revision.author?.full_name ?? revision.author?.email ?? 'Bilinmeyen Kullanıcı'}
+              </p>
+              <p className="mt-2 text-sm text-gray-700">{revision.description}</p>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/tasks/task-card.tsx
+++ b/components/tasks/task-card.tsx
@@ -4,10 +4,12 @@ import { Task } from '@/lib/types'
 import { formatDate } from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { getStatusLabel, normalizeStatus } from '@/lib/task-status'
 
 interface TaskCardProps {
   task: Task
   onDelete: (task: Task) => void
+  onOpen: (task: Task) => void
 }
 
 const priorityBadges: Record<Task['priority'], { label: string; color: 'orange' | 'gray' | 'green' }> = {
@@ -16,7 +18,8 @@ const priorityBadges: Record<Task['priority'], { label: string; color: 'orange' 
   high: { label: 'Yüksek Öncelik', color: 'orange' }
 }
 
-export function TaskCard({ task, onDelete }: TaskCardProps) {
+export function TaskCard({ task, onDelete, onOpen }: TaskCardProps) {
+  const status = normalizeStatus(task.status)
   return (
     <div className="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm">
       <div className="flex items-start justify-between">
@@ -27,10 +30,18 @@ export function TaskCard({ task, onDelete }: TaskCardProps) {
         <Badge color={priorityBadges[task.priority].color}>{priorityBadges[task.priority].label}</Badge>
       </div>
       <div className="mt-4 flex items-center justify-between text-xs text-gray-500">
-        <span>Bitiş: {formatDate(task.due_date)}</span>
-        <Button variant="ghost" className="text-red-500" onClick={() => onDelete(task)}>
-          Sil
-        </Button>
+        <div className="flex flex-col gap-1">
+          <span>Bitiş: {formatDate(task.due_date)}</span>
+          <span className="text-[11px] font-medium text-accent">Durum: {getStatusLabel(status)}</span>
+        </div>
+        <div className="flex items-center gap-1">
+          <Button variant="secondary" className="text-xs" onClick={() => onOpen(task)}>
+            Detay
+          </Button>
+          <Button variant="ghost" className="text-red-500" onClick={() => onDelete(task)}>
+            Sil
+          </Button>
+        </div>
       </div>
     </div>
   )

--- a/components/tasks/task-details.tsx
+++ b/components/tasks/task-details.tsx
@@ -1,0 +1,312 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Task, Comment, Revision } from '@/lib/types'
+import { Button } from '@/components/ui/button'
+import { formatDateTime, formatDate } from '@/lib/utils'
+import { getStatusLabel, normalizeStatus, TASK_STATUS_ORDER } from '@/lib/task-status'
+import { TaskForm } from './task-form'
+import { useToast } from '@/components/providers/toast-provider'
+
+const priorityLabels: Record<Task['priority'], string> = {
+  low: 'Düşük',
+  medium: 'Orta',
+  high: 'Yüksek'
+}
+
+interface TaskDetailsProps {
+  task: Task
+  projects: { id: string; title: string }[]
+  onClose: () => void
+  onTaskUpdated: (task: Task) => void
+}
+
+interface CommentResponse {
+  comment: Comment
+  revision: Revision | null
+}
+
+export function TaskDetails({ task, projects, onClose, onTaskUpdated }: TaskDetailsProps) {
+  const [currentTask, setCurrentTask] = useState<Task>(task)
+  const [comments, setComments] = useState<Comment[]>([])
+  const [revisions, setRevisions] = useState<Revision[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [isCommentLoading, setIsCommentLoading] = useState(false)
+  const [commentText, setCommentText] = useState('')
+  const [status, setStatus] = useState(normalizeStatus(task.status))
+  const [statusLoading, setStatusLoading] = useState(false)
+  const [isEditing, setIsEditing] = useState(false)
+  const { toast } = useToast()
+
+  const projectName = useMemo(() => {
+    if (!currentTask.project_id) return 'Proje atanmamış'
+    return projects.find((project) => project.id === currentTask.project_id)?.title ?? 'Proje bulunamadı'
+  }, [currentTask.project_id, projects])
+
+  const loadDetails = useCallback(async () => {
+    setIsLoading(true)
+    try {
+      const [commentsRes, revisionsRes] = await Promise.all([
+        fetch(`/api/tasks/${task.id}/comments`),
+        fetch(`/api/tasks/${task.id}/revisions`)
+      ])
+
+      if (commentsRes.ok) {
+        const data = (await commentsRes.json()) as Comment[]
+        setComments(data)
+      } else {
+        const error = await commentsRes.json()
+        toast({
+          title: 'Yorumlar yüklenemedi',
+          description: error.error ?? 'Beklenmedik bir hata oluştu.',
+          variant: 'error'
+        })
+        setComments([])
+      }
+
+      if (revisionsRes.ok) {
+        const data = (await revisionsRes.json()) as Revision[]
+        setRevisions(data)
+      } else {
+        const error = await revisionsRes.json()
+        toast({
+          title: 'Revize geçmişi yüklenemedi',
+          description: error.error ?? 'Beklenmedik bir hata oluştu.',
+          variant: 'error'
+        })
+        setRevisions([])
+      }
+    } catch (error) {
+      toast({
+        title: 'Detaylar yüklenemedi',
+        description: error instanceof Error ? error.message : 'Beklenmedik bir hata oluştu.',
+        variant: 'error'
+      })
+      setComments([])
+      setRevisions([])
+    } finally {
+      setIsLoading(false)
+    }
+  }, [task.id, toast])
+
+  useEffect(() => {
+    setCurrentTask(task)
+    setStatus(normalizeStatus(task.status))
+  }, [task])
+
+  useEffect(() => {
+    loadDetails()
+  }, [loadDetails])
+
+  const handleAddComment = async () => {
+    const trimmed = commentText.trim()
+    if (!trimmed) return
+    setIsCommentLoading(true)
+    try {
+      const response = await fetch(`/api/tasks/${task.id}/comments`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content: trimmed })
+      })
+
+      if (!response.ok) {
+        const data = await response.json()
+        toast({ title: 'Yorum eklenemedi', description: data.error ?? 'Bir hata oluştu.', variant: 'error' })
+        return
+      }
+
+      const data = (await response.json()) as CommentResponse
+      setComments((prev) => [...prev, data.comment])
+      if (data.revision) {
+        setRevisions((prev) => [data.revision, ...prev])
+      }
+      setCommentText('')
+      toast({ title: 'Yorum paylaşıldı', description: 'Görevin revize geçmişine eklendi.', variant: 'success' })
+    } catch (error) {
+      toast({
+        title: 'Yorum eklenemedi',
+        description: error instanceof Error ? error.message : 'Beklenmedik bir hata oluştu.',
+        variant: 'error'
+      })
+    } finally {
+      setIsCommentLoading(false)
+    }
+  }
+
+  const handleStatusChange = async (nextStatus: Task['status']) => {
+    if (statusLoading) return
+    const normalizedNext = normalizeStatus(nextStatus)
+    const previousStatus = status
+    setStatus(normalizedNext)
+    setStatusLoading(true)
+    try {
+      const response = await fetch(`/api/tasks/${task.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: nextStatus })
+      })
+
+      if (!response.ok) {
+        const data = await response.json()
+        toast({ title: 'Durum güncellenemedi', description: data.error ?? 'Bir hata oluştu.', variant: 'error' })
+        setStatus(previousStatus)
+        return
+      }
+
+      const updatedTask = (await response.json()) as Task
+      const normalizedUpdated = normalizeStatus(updatedTask.status)
+      const nextTask = { ...updatedTask, status: normalizedUpdated }
+      setCurrentTask(nextTask)
+      setStatus(normalizedUpdated)
+      onTaskUpdated(nextTask)
+      toast({
+        title: 'Durum güncellendi',
+        description: `${getStatusLabel(normalizedUpdated)} aşamasına taşındı.`,
+        variant: 'success'
+      })
+      loadDetails()
+    } catch (error) {
+      toast({
+        title: 'Durum güncellenemedi',
+        description: error instanceof Error ? error.message : 'Beklenmedik bir hata oluştu.',
+        variant: 'error'
+      })
+      setStatus(previousStatus)
+    } finally {
+      setStatusLoading(false)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      {isEditing ? (
+        <TaskForm
+          initialData={currentTask}
+          projects={projects}
+          onSuccess={(updatedTask) => {
+            setIsEditing(false)
+            setCurrentTask(updatedTask)
+            setStatus(normalizeStatus(updatedTask.status))
+            onTaskUpdated(updatedTask)
+            loadDetails()
+          }}
+        />
+      ) : (
+        <>
+          <div className="space-y-4">
+            <div className="flex items-start justify-between">
+              <div>
+                <h3 className="text-lg font-semibold text-gray-900">{currentTask.title}</h3>
+                <p className="mt-1 text-sm text-gray-500">{currentTask.description}</p>
+              </div>
+              <Button variant="secondary" onClick={() => setIsEditing(true)}>
+                Görevi Düzenle
+              </Button>
+            </div>
+            <div className="grid gap-4 rounded-2xl border border-gray-200 bg-gray-50 p-4 text-sm text-gray-600 md:grid-cols-3">
+              <div>
+                <p className="text-xs uppercase text-gray-500">Proje</p>
+                <p className="font-medium text-gray-900">{projectName}</p>
+              </div>
+              <div>
+                <p className="text-xs uppercase text-gray-500">Teslim Tarihi</p>
+                <p className="font-medium text-gray-900">{formatDate(currentTask.due_date) || 'Belirlenmedi'}</p>
+              </div>
+              <div>
+                <p className="text-xs uppercase text-gray-500">Öncelik</p>
+                <p className="font-medium text-gray-900">{priorityLabels[currentTask.priority]}</p>
+              </div>
+            </div>
+          </div>
+
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <h4 className="text-sm font-semibold text-gray-900">Durum</h4>
+              <span className="text-xs text-gray-500">{getStatusLabel(status)}</span>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {TASK_STATUS_ORDER.map((taskStatus) => {
+                const isActive = status === taskStatus
+                return (
+                  <button
+                    key={taskStatus}
+                    disabled={statusLoading}
+                    onClick={() => handleStatusChange(taskStatus)}
+                    className={`rounded-full px-4 py-2 text-xs font-medium transition ${
+                      isActive
+                        ? 'bg-accent text-white shadow'
+                        : 'bg-white text-gray-600 ring-1 ring-gray-200 hover:text-gray-900'
+                    }`}
+                  >
+                    {getStatusLabel(taskStatus)}
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+
+          <div className="space-y-3">
+            <h4 className="text-sm font-semibold text-gray-900">Yorumlar</h4>
+            {isLoading ? (
+              <p className="text-sm text-gray-500">Yorumlar yükleniyor...</p>
+            ) : comments.length === 0 ? (
+              <p className="text-sm text-gray-500">Henüz yorum yapılmamış. İlk yorumu sen ekle.</p>
+            ) : (
+              <div className="space-y-3">
+                {comments.map((comment) => (
+                  <div key={comment.id} className="rounded-2xl border border-gray-200 bg-white p-3">
+                    <div className="flex items-center justify-between text-xs text-gray-500">
+                      <span>{comment.author?.full_name ?? comment.author?.email ?? 'Kullanıcı'}</span>
+                      <span>{formatDateTime(comment.created_at)}</span>
+                    </div>
+                    <p className="mt-2 text-sm text-gray-700">{comment.content}</p>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            <div className="rounded-2xl border border-dashed border-gray-300 p-4">
+              <textarea
+                rows={3}
+                value={commentText}
+                onChange={(event) => setCommentText(event.target.value)}
+                placeholder="Görev ile ilgili güncel durum ya da not ekleyin"
+                className="w-full resize-none bg-white"
+              ></textarea>
+              <Button className="mt-3" onClick={handleAddComment} disabled={isCommentLoading}>
+                {isCommentLoading ? 'Gönderiliyor...' : 'Yorumu Paylaş'}
+              </Button>
+            </div>
+          </div>
+
+          <div className="space-y-3">
+            <h4 className="text-sm font-semibold text-gray-900">Revize Geçmişi</h4>
+            {isLoading ? (
+              <p className="text-sm text-gray-500">Geçmiş yükleniyor...</p>
+            ) : revisions.length === 0 ? (
+              <p className="text-sm text-gray-500">Henüz revize geçmişi bulunmuyor.</p>
+            ) : (
+              <div className="space-y-3">
+                {revisions.map((revision) => (
+                  <div key={revision.id} className="rounded-2xl border border-gray-200 bg-white p-3">
+                    <div className="flex items-center justify-between text-xs text-gray-500">
+                      <span>{revision.author?.full_name ?? revision.author?.email ?? 'Kullanıcı'}</span>
+                      <span>{formatDateTime(revision.created_at)}</span>
+                    </div>
+                    <p className="mt-2 text-sm text-gray-700">{revision.description}</p>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <div className="flex justify-end">
+            <Button variant="secondary" onClick={onClose}>
+              Kapat
+            </Button>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/components/tasks/task-form.tsx
+++ b/components/tasks/task-form.tsx
@@ -2,10 +2,12 @@
 
 import { useState, FormEvent } from 'react'
 import { Task } from '@/lib/types'
+import { useToast } from '@/components/providers/toast-provider'
+import { normalizeStatus, TASK_STATUS_ORDER, getStatusLabel } from '@/lib/task-status'
 import { Button } from '@/components/ui/button'
 
 interface TaskFormProps {
-  onSuccess: () => void
+  onSuccess: (task: Task) => void
   projects: { id: string; title: string }[]
   initialData?: Task
 }
@@ -13,42 +15,69 @@ interface TaskFormProps {
 export function TaskForm({ onSuccess, projects, initialData }: TaskFormProps) {
   const [title, setTitle] = useState(initialData?.title ?? '')
   const [description, setDescription] = useState(initialData?.description ?? '')
-  const [status, setStatus] = useState<Task['status']>(initialData?.status ?? 'todo')
+  const [status, setStatus] = useState<Task['status']>(initialData ? normalizeStatus(initialData.status) : 'todo')
   const [priority, setPriority] = useState<Task['priority']>(initialData?.priority ?? 'medium')
   const [dueDate, setDueDate] = useState(initialData?.due_date?.slice(0, 10) ?? '')
   const [projectId, setProjectId] = useState(initialData?.project_id ?? '')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const { toast } = useToast()
 
   const handleSubmit = async (event: FormEvent) => {
     event.preventDefault()
-    setLoading(true)
-    setError(null)
-
-    const response = await fetch(initialData ? `/api/tasks/${initialData.id}` : '/api/tasks', {
-      method: initialData ? 'PUT' : 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({
-        title,
-        description,
-        status,
-        priority,
-        due_date: dueDate,
-        project_id: projectId || null
-      })
-    })
-
-    setLoading(false)
-
-    if (!response.ok) {
-      const data = await response.json()
-      setError(data.error ?? 'Bir hata oluştu')
+    const trimmedTitle = title.trim()
+    if (!trimmedTitle) {
+      setError('Görev başlığı gerekli')
+      toast({ title: 'İşlem başarısız', description: 'Görev başlığı gerekli.', variant: 'error' })
       return
     }
 
-    onSuccess()
+    setLoading(true)
+    setError(null)
+
+    const payload = {
+      title: trimmedTitle,
+      description: description.trim() ? description.trim() : null,
+      status,
+      priority,
+      due_date: dueDate ? dueDate : null,
+      project_id: projectId || null
+    }
+
+    try {
+      const response = await fetch(initialData ? `/api/tasks/${initialData.id}` : '/api/tasks', {
+        method: initialData ? 'PUT' : 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(payload)
+      })
+
+      if (!response.ok) {
+        const data = await response.json()
+        setError(data.error ?? 'Bir hata oluştu')
+        toast({ title: 'İşlem başarısız', description: data.error ?? 'Görev kaydedilemedi.', variant: 'error' })
+        return
+      }
+
+      const data = (await response.json()) as Task
+      const normalizedTask = { ...data, status: normalizeStatus(data.status) }
+
+      toast({
+        title: initialData ? 'Görev güncellendi' : 'Görev oluşturuldu',
+        description: initialData
+          ? 'Görev bilgileri başarıyla kaydedildi.'
+          : 'Yeni göreviniz panoya eklendi.',
+        variant: 'success'
+      })
+      onSuccess(normalizedTask)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Görev kaydedilemedi.'
+      setError(message)
+      toast({ title: 'İşlem başarısız', description: message, variant: 'error' })
+    } finally {
+      setLoading(false)
+    }
   }
 
   return (
@@ -65,9 +94,11 @@ export function TaskForm({ onSuccess, projects, initialData }: TaskFormProps) {
         <div>
           <label className="text-sm font-medium text-gray-700">Durum</label>
           <select value={status} onChange={(e) => setStatus(e.target.value as Task['status'])}>
-            <option value="todo">Yapılacak</option>
-            <option value="in_progress">Devam Ediyor</option>
-            <option value="done">Tamamlandı</option>
+            {TASK_STATUS_ORDER.map((taskStatus) => (
+              <option key={taskStatus} value={taskStatus}>
+                {getStatusLabel(taskStatus)}
+              </option>
+            ))}
           </select>
         </div>
         <div>

--- a/lib/supabase-types.ts
+++ b/lib/supabase-types.ts
@@ -14,6 +14,7 @@ export type Database = {
           push_notifications: boolean | null
           weekly_summary: boolean | null
           created_at: string
+          role: 'admin' | 'user' | null
         }
         Insert: {
           id: string
@@ -24,6 +25,7 @@ export type Database = {
           email_notifications?: boolean | null
           push_notifications?: boolean | null
           weekly_summary?: boolean | null
+          role?: 'admin' | 'user' | null
         }
         Update: Partial<Database['public']['Tables']['profiles']['Insert']>
       }
@@ -52,7 +54,7 @@ export type Database = {
           id: string
           title: string
           description: string | null
-          status: 'todo' | 'in_progress' | 'done'
+          status: 'todo' | 'in_progress' | 'in_review' | 'revision' | 'approved' | 'published' | 'done'
           priority: 'low' | 'medium' | 'high'
           due_date: string | null
           project_id: string | null
@@ -63,13 +65,68 @@ export type Database = {
           id?: string
           title: string
           description?: string | null
-          status?: 'todo' | 'in_progress' | 'done'
+          status?: 'todo' | 'in_progress' | 'in_review' | 'revision' | 'approved' | 'published' | 'done'
           priority?: 'low' | 'medium' | 'high'
           due_date?: string | null
           project_id?: string | null
           user_id: string
         }
         Update: Partial<Database['public']['Tables']['tasks']['Insert']>
+      }
+      comments: {
+        Row: {
+          id: string
+          task_id: string
+          user_id: string
+          content: string
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          task_id: string
+          user_id: string
+          content: string
+          created_at?: string
+        }
+        Update: Partial<Database['public']['Tables']['comments']['Insert']>
+      }
+      revisions: {
+        Row: {
+          id: string
+          task_id: string
+          user_id: string
+          comment_id: string | null
+          description: string
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          task_id: string
+          user_id: string
+          comment_id?: string | null
+          description: string
+          created_at?: string
+        }
+        Update: Partial<Database['public']['Tables']['revisions']['Insert']>
+      }
+      goals: {
+        Row: {
+          id: string
+          title: string
+          description: string | null
+          is_completed: boolean
+          user_id: string
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          title: string
+          description?: string | null
+          is_completed?: boolean
+          user_id: string
+          created_at?: string
+        }
+        Update: Partial<Database['public']['Tables']['goals']['Insert']>
       }
     }
   }

--- a/lib/task-status.ts
+++ b/lib/task-status.ts
@@ -1,0 +1,36 @@
+import { TaskStatus } from './types'
+
+export const TASK_STATUS_ORDER: TaskStatus[] = [
+  'todo',
+  'in_progress',
+  'in_review',
+  'revision',
+  'approved',
+  'published'
+]
+
+export const TASK_STATUS_LABELS: Record<TaskStatus, string> = {
+  todo: 'Beklemede',
+  in_progress: 'Yapılıyor',
+  in_review: 'Onay Sürecinde',
+  revision: 'Revize',
+  approved: 'Onaylandı',
+  published: 'Paylaşıldı',
+  done: 'Tamamlandı'
+}
+
+export const COMPLETED_STATUSES: TaskStatus[] = ['approved', 'published', 'done']
+
+export function normalizeStatus(status: TaskStatus): TaskStatus {
+  if (status === 'done') {
+    return 'approved'
+  }
+  if (!TASK_STATUS_ORDER.includes(status)) {
+    return 'todo'
+  }
+  return status
+}
+
+export function getStatusLabel(status: TaskStatus) {
+  return TASK_STATUS_LABELS[status] ?? status
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -7,6 +7,7 @@ export type Profile = {
   email_notifications?: boolean
   push_notifications?: boolean
   weekly_summary?: boolean
+  role?: 'admin' | 'user'
 }
 
 export type Project = {
@@ -16,15 +17,60 @@ export type Project = {
   progress: number
   due_date: string | null
   user_id: string
+  created_at?: string
 }
+
+export type TaskStatus =
+  | 'todo'
+  | 'in_progress'
+  | 'in_review'
+  | 'revision'
+  | 'approved'
+  | 'published'
+  | 'done'
 
 export type Task = {
   id: string
   title: string
   description: string | null
-  status: 'todo' | 'in_progress' | 'done'
+  status: TaskStatus
   priority: 'low' | 'medium' | 'high'
   due_date: string | null
   project_id: string | null
   user_id: string
+  created_at?: string
+}
+
+export type Comment = {
+  id: string
+  task_id: string
+  user_id: string
+  content: string
+  created_at: string
+  author?: {
+    full_name: string | null
+    email: string | null
+  }
+}
+
+export type Revision = {
+  id: string
+  task_id: string
+  user_id: string
+  comment_id: string | null
+  description: string
+  created_at: string
+  author?: {
+    full_name: string | null
+    email: string | null
+  }
+}
+
+export type Goal = {
+  id: string
+  title: string
+  description: string | null
+  is_completed: boolean
+  user_id: string
+  created_at?: string
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -14,6 +14,17 @@ export function formatDate(date: string | null) {
   }).format(new Date(date))
 }
 
+export function formatDateTime(date: string | null) {
+  if (!date) return ''
+  return new Intl.DateTimeFormat('tr-TR', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit'
+  }).format(new Date(date))
+}
+
 export function getInitials(fullName?: string | null) {
   if (!fullName) return 'K'
   const parts = fullName.split(' ')

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -8,6 +8,7 @@ create table if not exists profiles (
   email_notifications boolean default true,
   push_notifications boolean default false,
   weekly_summary boolean default true,
+  role text default 'user',
   created_at timestamp with time zone default timezone('utc'::text, now())
 );
 
@@ -42,8 +43,43 @@ create table if not exists tasks (
 alter table tasks enable row level security;
 create policy if not exists "tasks_policy" on tasks for all using (auth.uid() = user_id) with check (auth.uid() = user_id);
 
-insert into profiles (id, full_name, email)
-values ('00000000-0000-0000-0000-000000000000', 'Demo Kullanıcı', 'demo@piktram.com')
+create table if not exists comments (
+  id uuid primary key default gen_random_uuid(),
+  task_id uuid not null references tasks(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  content text not null,
+  created_at timestamp with time zone default timezone('utc'::text, now())
+);
+
+alter table comments enable row level security;
+create policy if not exists "comments_policy" on comments for all using (auth.uid() = user_id) with check (auth.uid() = user_id);
+
+create table if not exists revisions (
+  id uuid primary key default gen_random_uuid(),
+  task_id uuid not null references tasks(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  comment_id uuid references comments(id) on delete set null,
+  description text not null,
+  created_at timestamp with time zone default timezone('utc'::text, now())
+);
+
+alter table revisions enable row level security;
+create policy if not exists "revisions_policy" on revisions for all using (auth.uid() = user_id) with check (auth.uid() = user_id);
+
+create table if not exists goals (
+  id uuid primary key default gen_random_uuid(),
+  title text not null,
+  description text,
+  is_completed boolean default false,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  created_at timestamp with time zone default timezone('utc'::text, now())
+);
+
+alter table goals enable row level security;
+create policy if not exists "goals_policy" on goals for all using (auth.uid() = user_id) with check (auth.uid() = user_id);
+
+insert into profiles (id, full_name, email, role)
+values ('00000000-0000-0000-0000-000000000000', 'Demo Kullanıcı', 'demo@piktram.com', 'admin')
 on conflict (id) do update set full_name = excluded.full_name;
 
 insert into projects (id, title, description, progress, due_date, user_id) values
@@ -52,7 +88,68 @@ insert into projects (id, title, description, progress, due_date, user_id) value
 on conflict (id) do update set title = excluded.title;
 
 insert into tasks (title, description, status, priority, due_date, project_id, user_id) values
-  ('Pazarlama Stratejisi', 'Sosyal medya kampanyalarını detaylandır ve onaya sun.', 'in_progress', 'high', current_date + interval '2 day', '11111111-1111-1111-1111-111111111111', '00000000-0000-0000-0000-000000000000'),
-  ('Tasarım Onayı', 'Yeni ana sayfa tasarımını ekip ile değerlendir.', 'todo', 'medium', current_date + interval '1 day', '11111111-1111-1111-1111-111111111111', '00000000-0000-0000-0000-000000000000'),
-  ('Test Senaryoları', 'Mobil uygulama için hata testlerini tamamla.', 'done', 'high', current_date - interval '1 day', '22222222-2222-2222-2222-222222222222', '00000000-0000-0000-0000-000000000000')
+  (
+    'Pazarlama Stratejisi',
+    'Sosyal medya kampanyalarını detaylandır ve onaya sun.',
+    'in_progress',
+    'high',
+    current_date + interval '2 day',
+    '11111111-1111-1111-1111-111111111111',
+    '00000000-0000-0000-0000-000000000000'
+  ),
+  (
+    'Tasarım Onayı',
+    'Yeni ana sayfa tasarımını ekip ile değerlendir.',
+    'in_review',
+    'medium',
+    current_date + interval '1 day',
+    '11111111-1111-1111-1111-111111111111',
+    '00000000-0000-0000-0000-000000000000'
+  ),
+  (
+    'Test Senaryoları',
+    'Mobil uygulama için hata testlerini tamamla.',
+    'approved',
+    'high',
+    current_date - interval '1 day',
+    '22222222-2222-2222-2222-222222222222',
+    '00000000-0000-0000-0000-000000000000'
+  )
+on conflict do nothing;
+
+insert into comments (id, task_id, user_id, content)
+values
+  (
+    '33333333-3333-3333-3333-333333333333',
+    '11111111-1111-1111-1111-111111111111',
+    '00000000-0000-0000-0000-000000000000',
+    'Görev ile ilgili ilk yorum. Pazarlama planı taslağı paylaşıldı.'
+  )
+on conflict (id) do nothing;
+
+insert into revisions (id, task_id, user_id, comment_id, description)
+values
+  (
+    '44444444-4444-4444-4444-444444444444',
+    '11111111-1111-1111-1111-111111111111',
+    '00000000-0000-0000-0000-000000000000',
+    '33333333-3333-3333-3333-333333333333',
+    'Görev için yorum eklendi ve revize kaydı oluşturuldu.'
+  )
+on conflict (id) do nothing;
+
+insert into goals (title, description, is_completed, user_id)
+values
+  (
+    'Haftalık içerik planını tamamla',
+    'Pazarlama ekibi ile koordineli şekilde içerik planını hazırla.',
+    false,
+    '00000000-0000-0000-0000-000000000000'
+  ),
+  (
+    'Yeni müşteri sunumunu bitir',
+    'Sunumu gözden geçir ve onaya hazır hale getir.',
+    true,
+    '00000000-0000-0000-0000-000000000000'
+  )
 on conflict do nothing;


### PR DESCRIPTION
## Summary
- add role-aware gating for the protected layout, surface the admin navigation entry, and expose a dedicated admin dashboard with aggregated task, project, goal and revision insights
- extend the Supabase profile schema/types with a persisted role flag plus a `/login` alias, and provide an access-denied experience for non-admin users
- enrich task comments and revision feeds with author metadata while hardening task detail actions, boards, and all goal/project forms with trimmed payloads, loading guards and toast-backed error handling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8f76b38a0832fb6c05063c1ea5546